### PR TITLE
Update 06transactions.asciidoc

### DIFF
--- a/06transactions.asciidoc
+++ b/06transactions.asciidoc
@@ -37,7 +37,7 @@ For example, you may notice there is no &#x201c;from&#x201d; data in the address
 [[tx_nonce]]
 === The Transaction Nonce
 
-((("nonces", id="ix_06transactions-asciidoc1", range="startofrange")))((("transactions","nonces", id="ix_06transactions-asciidoc2", range="startofrange")))The nonce is one of the most important and least understood components of a transaction. The definition in the Yellow Paper (see <<references>>) reads:
+((("nonces", id="ix_06transactions-asciidoc1", range="startofrange")))((("transactions","nonces", id="ix_06transactions-asciidoc2", range="startofrange")))The nonce is one of the most important and least understood components of a transaction. The definition in the Yellow Paper [see <<references>>](https://ethereum.github.io/yellowpaper/paper.pdf) reads:
 
 ____
 +nonce+: A scalar value equal to the number of transactions sent from this address or, in the case of accounts with associated code, the number of contract-creations made by this account.


### PR DESCRIPTION
The Transaction Nonce has a dead link on the reference to the Yellow Paper. i have updated the link to enable new user to be able to access the Yellow Paper documentation easily as refered.